### PR TITLE
Add using statement for projects without implicit using activated

### DIFF
--- a/BetterEnums/BetterEnums.csproj
+++ b/BetterEnums/BetterEnums.csproj
@@ -14,7 +14,7 @@
 	  <PackageTags>csharp;csharp-sourcegenerators;source-generator;sourcegenerator;csharp-sourcegenerator;enum;enums</PackageTags>
 	  <AssemblyVersion></AssemblyVersion>
 	  <FileVersion></FileVersion>
-	  <Version>1.0.1</Version>
+	  <Version>1.0.2</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/BetterEnums/BetterEnumsSources.cs
+++ b/BetterEnums/BetterEnumsSources.cs
@@ -15,6 +15,7 @@ namespace {NAMESPACE} {{
 		public static readonly string ENUM_EXTENSION_SOURCE_START = $@"
 using System;
 using System.Reflection;
+using System.Linq;
 namespace {NAMESPACE} {{
 	public static class {EXTENSION} {{";
 


### PR DESCRIPTION
I got an error in BetterEnumExtensions.cs in a project, which doesn't have the ImplicitUsing activated. It was an Error because of the Linq methods in GetEnumAttributes.

I fixed it with an explicit using of System.Linq!